### PR TITLE
A few additional fixes

### DIFF
--- a/wp-cli-cac.php
+++ b/wp-cli-cac.php
@@ -4,8 +4,10 @@ if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 	require __DIR__  . '/vendor/autoload.php';
 }
 
-// Bail if WP-CLI is not present.
-defined( 'WP_CLI' ) || die();
+// Register our command if WP-CLI is available.
+if ( defined( 'WP_CLI' ) ) {
+	WP_CLI::add_command( 'cac', 'CAC_Command' );
+}
 
 class CAC_Command extends WP_CLI_Command {
 	protected $update_blacklist = array(
@@ -567,5 +569,3 @@ class CAC_Command extends WP_CLI_Command {
 		}
 	}
 }
-
-WP_CLI::add_command( 'cac', 'CAC_Command' );

--- a/wp-cli-cac.php
+++ b/wp-cli-cac.php
@@ -1,6 +1,8 @@
 <?php
-
-require 'vendor/autoload.php';
+// Load autoloader if available.
+if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
+	require __DIR__  . '/vendor/autoload.php';
+}
 
 // Bail if WP-CLI is not present.
 defined( 'WP_CLI' ) || die();


### PR DESCRIPTION
Hi Boone,

So I'm not using WP-CLI's `wp package install` command to install `wp-cli-cac`.  I'm including them manually in `/mu-plugins/` on my local CAC set up.

In order for this to work, I needed to conditionally check if the autoloader is available since I'm installing `wp-cli-cac` and `wp-cli-git-helper` separately and the autoloader here isn't necessary for my needs.

I'm also only registering the `cac` command if WP-CLI is available.

Let me know what you think.